### PR TITLE
Add order and shipment mock APIs

### DIFF
--- a/src/dotnetLab.Persistence.Repositories/Implements/OrderMockRepository.cs
+++ b/src/dotnetLab.Persistence.Repositories/Implements/OrderMockRepository.cs
@@ -1,0 +1,26 @@
+using dotnetLab.Domains.Orders;
+using dotnetLab.Persistence.Repositories.Implements;
+using dotnetLab.UseCases.Orders.Ports.Out;
+
+namespace dotnetLab.Persistence.Repositories.Implements;
+
+/// <summary>
+/// Order mock repository
+/// </summary>
+public class OrderMockRepository : IOrderRepository
+{
+    /// <inheritdoc />
+    public Task<Order?> GetAsync(Guid orderId)
+    {
+        var order = new Order(orderId, "Mock Customer");
+        order.AddOrderLine(Guid.NewGuid(), "Product A", 10m, 2);
+        order.AddOrderLine(Guid.NewGuid(), "Product B", 20m, 1);
+        return Task.FromResult<Order?>(order);
+    }
+
+    /// <inheritdoc />
+    public Task<Guid> SaveAsync(Order order)
+    {
+        return Task.FromResult(order.Id);
+    }
+}

--- a/src/dotnetLab.Persistence.Repositories/Implements/ShipmentMockRepository.cs
+++ b/src/dotnetLab.Persistence.Repositories/Implements/ShipmentMockRepository.cs
@@ -1,0 +1,38 @@
+using dotnetLab.Domains.Shipments;
+using dotnetLab.Domains.Shipments.ValueObjects;
+using dotnetLab.Persistence.Repositories.Implements;
+using dotnetLab.UseCases.Shipments.Ports.Out;
+
+namespace dotnetLab.Persistence.Repositories.Implements;
+
+/// <summary>
+/// Shipment mock repository
+/// </summary>
+public class ShipmentMockRepository : IShipmentRepository
+{
+    /// <inheritdoc />
+    public Task<Shipment?> GetAsync(Guid shipmentId)
+    {
+        var address = new Address("Street 1", "City", "State", "00000", "Country", "Tester", "0912345678");
+        var orderLine = new OrderLineSnapshot(
+            Guid.NewGuid(),
+            "Product A",
+            1,
+            1.0m,
+            "10x10x10",
+            false);
+        var orderSnapshot = new OrderSnapshot(
+            shipmentId,
+            "Mock Customer",
+            DateTime.UtcNow,
+            new[] { orderLine });
+        var shipment = new Shipment(shipmentId, orderSnapshot, address);
+        return Task.FromResult<Shipment?>(shipment);
+    }
+
+    /// <inheritdoc />
+    public Task<Guid> SaveAsync(Shipment shipment)
+    {
+        return Task.FromResult(shipment.Id);
+    }
+}

--- a/src/dotnetLab.Persistence.Repositories/ServiceCollectionExtension.cs
+++ b/src/dotnetLab.Persistence.Repositories/ServiceCollectionExtension.cs
@@ -2,6 +2,8 @@
 using dotnetLab.Persistence.Repositories.Factories;
 using dotnetLab.Persistence.Repositories.Implements;
 using dotnetLab.UseCases.SimpleDocument.Ports.Out;
+using dotnetLab.UseCases.Orders.Ports.Out;
+using dotnetLab.UseCases.Shipments.Ports.Out;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,6 +19,8 @@ public static class ServiceCollectionExtension
         // serviceCollection.AddDbConnectionFactory();
 
         serviceCollection.AddSimpleDocumentRepository();
+        serviceCollection.AddOrderRepository();
+        serviceCollection.AddShipmentRepository();
 
         return serviceCollection;
     }
@@ -55,6 +59,18 @@ public static class ServiceCollectionExtension
 
         // serviceCollection.AddScoped<ISimpleDocumentRepository, GrpcSampleDataRepository>();
 
+        return serviceCollection;
+    }
+
+    private static IServiceCollection AddOrderRepository(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped<IOrderRepository, OrderMockRepository>();
+        return serviceCollection;
+    }
+
+    private static IServiceCollection AddShipmentRepository(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped<IShipmentRepository, ShipmentMockRepository>();
         return serviceCollection;
     }
 }

--- a/src/dotnetLab.UseCases/Orders/Dtos/OrderDto.cs
+++ b/src/dotnetLab.UseCases/Orders/Dtos/OrderDto.cs
@@ -1,0 +1,27 @@
+namespace dotnetLab.UseCases.Orders.Dtos;
+
+/// <summary>
+/// 訂單資料
+/// </summary>
+public class OrderDto
+{
+    /// <summary>
+    /// 訂單識別碼
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 客戶名稱
+    /// </summary>
+    public string CustomerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 訂單日期
+    /// </summary>
+    public DateTime OrderDate { get; set; }
+
+    /// <summary>
+    /// 總金額
+    /// </summary>
+    public decimal TotalAmount { get; set; }
+}

--- a/src/dotnetLab.UseCases/Orders/Ports/Out/IOrderRepository.cs
+++ b/src/dotnetLab.UseCases/Orders/Ports/Out/IOrderRepository.cs
@@ -1,0 +1,23 @@
+using dotnetLab.Domains.Orders;
+
+namespace dotnetLab.UseCases.Orders.Ports.Out;
+
+/// <summary>
+/// 訂單 Repository
+/// </summary>
+public interface IOrderRepository
+{
+    /// <summary>
+    /// 依識別碼取得訂單
+    /// </summary>
+    /// <param name="orderId"></param>
+    /// <returns></returns>
+    Task<Order?> GetAsync(Guid orderId);
+
+    /// <summary>
+    /// 儲存訂單
+    /// </summary>
+    /// <param name="order"></param>
+    /// <returns></returns>
+    Task<Guid> SaveAsync(Order order);
+}

--- a/src/dotnetLab.UseCases/Orders/Queries/GetOrderQuery.cs
+++ b/src/dotnetLab.UseCases/Orders/Queries/GetOrderQuery.cs
@@ -1,0 +1,12 @@
+namespace dotnetLab.UseCases.Orders.Queries;
+
+/// <summary>
+/// 取得訂單查詢
+/// </summary>
+public class GetOrderQuery
+{
+    /// <summary>
+    /// 訂單識別碼
+    /// </summary>
+    public Guid OrderId { get; set; }
+}

--- a/src/dotnetLab.UseCases/Orders/Queries/GetOrderQueryHandler.cs
+++ b/src/dotnetLab.UseCases/Orders/Queries/GetOrderQueryHandler.cs
@@ -1,0 +1,46 @@
+using dotnetLab.UseCases.Orders.Dtos;
+using dotnetLab.UseCases.Orders.Ports.Out;
+
+namespace dotnetLab.UseCases.Orders.Queries;
+
+/// <summary>
+/// 取得訂單處理程序
+/// </summary>
+public class GetOrderQueryHandler
+{
+    private readonly IOrderRepository _orderRepository;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="orderRepository"></param>
+    public GetOrderQueryHandler(IOrderRepository orderRepository)
+    {
+        this._orderRepository = orderRepository;
+    }
+
+    /// <summary>
+    /// 取得訂單
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async ValueTask<OrderDto?> Handle(GetOrderQuery request, CancellationToken cancellationToken)
+    {
+        var order = await this._orderRepository.GetAsync(request.OrderId);
+        if (order == null)
+        {
+            return null;
+        }
+
+        var dto = new OrderDto
+        {
+            Id = order.Id,
+            CustomerName = order.CustomerName,
+            OrderDate = order.OrderDate,
+            TotalAmount = order.TotalAmount
+        };
+
+        return dto;
+    }
+}

--- a/src/dotnetLab.UseCases/Shipments/Dtos/ShipmentDto.cs
+++ b/src/dotnetLab.UseCases/Shipments/Dtos/ShipmentDto.cs
@@ -1,0 +1,22 @@
+namespace dotnetLab.UseCases.Shipments.Dtos;
+
+/// <summary>
+/// 貨運資料
+/// </summary>
+public class ShipmentDto
+{
+    /// <summary>
+    /// 貨運識別碼
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 追蹤號碼
+    /// </summary>
+    public string TrackingNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 狀態
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+}

--- a/src/dotnetLab.UseCases/Shipments/Ports/Out/IShipmentRepository.cs
+++ b/src/dotnetLab.UseCases/Shipments/Ports/Out/IShipmentRepository.cs
@@ -1,0 +1,23 @@
+using dotnetLab.Domains.Shipments;
+
+namespace dotnetLab.UseCases.Shipments.Ports.Out;
+
+/// <summary>
+/// 貨運 Repository
+/// </summary>
+public interface IShipmentRepository
+{
+    /// <summary>
+    /// 依識別碼取得貨運
+    /// </summary>
+    /// <param name="shipmentId"></param>
+    /// <returns></returns>
+    Task<Shipment?> GetAsync(Guid shipmentId);
+
+    /// <summary>
+    /// 儲存貨運
+    /// </summary>
+    /// <param name="shipment"></param>
+    /// <returns></returns>
+    Task<Guid> SaveAsync(Shipment shipment);
+}

--- a/src/dotnetLab.UseCases/Shipments/Queries/GetShipmentQuery.cs
+++ b/src/dotnetLab.UseCases/Shipments/Queries/GetShipmentQuery.cs
@@ -1,0 +1,12 @@
+namespace dotnetLab.UseCases.Shipments.Queries;
+
+/// <summary>
+/// 取得貨運查詢
+/// </summary>
+public class GetShipmentQuery
+{
+    /// <summary>
+    /// 貨運識別碼
+    /// </summary>
+    public Guid ShipmentId { get; set; }
+}

--- a/src/dotnetLab.UseCases/Shipments/Queries/GetShipmentQueryHandler.cs
+++ b/src/dotnetLab.UseCases/Shipments/Queries/GetShipmentQueryHandler.cs
@@ -1,0 +1,45 @@
+using dotnetLab.UseCases.Shipments.Dtos;
+using dotnetLab.UseCases.Shipments.Ports.Out;
+
+namespace dotnetLab.UseCases.Shipments.Queries;
+
+/// <summary>
+/// 取得貨運處理程序
+/// </summary>
+public class GetShipmentQueryHandler
+{
+    private readonly IShipmentRepository _shipmentRepository;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="shipmentRepository"></param>
+    public GetShipmentQueryHandler(IShipmentRepository shipmentRepository)
+    {
+        this._shipmentRepository = shipmentRepository;
+    }
+
+    /// <summary>
+    /// 取得貨運
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async ValueTask<ShipmentDto?> Handle(GetShipmentQuery request, CancellationToken cancellationToken)
+    {
+        var shipment = await this._shipmentRepository.GetAsync(request.ShipmentId);
+        if (shipment == null)
+        {
+            return null;
+        }
+
+        var dto = new ShipmentDto
+        {
+            Id = shipment.Id,
+            TrackingNumber = shipment.TrackingNumber,
+            Status = shipment.Status.ToString()
+        };
+
+        return dto;
+    }
+}

--- a/src/dotnetLab.WebApi/Controllers/OrdersController.cs
+++ b/src/dotnetLab.WebApi/Controllers/OrdersController.cs
@@ -1,0 +1,51 @@
+using dotnetLab.UseCases.Orders.Dtos;
+using dotnetLab.UseCases.Orders.Queries;
+using dotnetLab.WebApi.Controllers.ViewModels;
+using dotnetLab.WebApi.Infrastructure.ResponseWrapper;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
+
+namespace dotnetLab.WebApi.Controllers;
+
+/// <summary>
+/// 訂單相關 API
+/// </summary>
+[ApiController]
+[Route("api/v{version:apiVersion}/orders")]
+public class OrdersController : ControllerBase
+{
+    private readonly IMessageBus _messageBus;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    public OrdersController(IMessageBus messageBus)
+    {
+        this._messageBus = messageBus;
+    }
+
+    /// <summary>
+    /// 取得訂單
+    /// </summary>
+    /// <param name="orderId"></param>
+    /// <returns></returns>
+    [HttpGet("{orderId}")]
+    [ProducesResponseType<ApiResponse<OrderViewModel>>(200)]
+    public async Task<IActionResult> Get(Guid orderId)
+    {
+        var dto = await this._messageBus.InvokeAsync<OrderDto?>(new GetOrderQuery { OrderId = orderId });
+        if (dto == null)
+        {
+            return this.NotFound();
+        }
+
+        var vm = new OrderViewModel
+        {
+            Id = dto.Id,
+            CustomerName = dto.CustomerName,
+            OrderDate = dto.OrderDate,
+            TotalAmount = dto.TotalAmount
+        };
+        return this.Ok(vm);
+    }
+}

--- a/src/dotnetLab.WebApi/Controllers/Requests/OrderQueryRequest.cs
+++ b/src/dotnetLab.WebApi/Controllers/Requests/OrderQueryRequest.cs
@@ -1,0 +1,12 @@
+namespace dotnetLab.WebApi.Controllers.Requests;
+
+/// <summary>
+/// 取得訂單 Request
+/// </summary>
+public class OrderQueryRequest
+{
+    /// <summary>
+    /// 訂單識別碼
+    /// </summary>
+    public Guid OrderId { get; set; }
+}

--- a/src/dotnetLab.WebApi/Controllers/Requests/ShipmentQueryRequest.cs
+++ b/src/dotnetLab.WebApi/Controllers/Requests/ShipmentQueryRequest.cs
@@ -1,0 +1,12 @@
+namespace dotnetLab.WebApi.Controllers.Requests;
+
+/// <summary>
+/// 取得貨運 Request
+/// </summary>
+public class ShipmentQueryRequest
+{
+    /// <summary>
+    /// 貨運識別碼
+    /// </summary>
+    public Guid ShipmentId { get; set; }
+}

--- a/src/dotnetLab.WebApi/Controllers/ShipmentsController.cs
+++ b/src/dotnetLab.WebApi/Controllers/ShipmentsController.cs
@@ -1,0 +1,50 @@
+using dotnetLab.UseCases.Shipments.Dtos;
+using dotnetLab.UseCases.Shipments.Queries;
+using dotnetLab.WebApi.Controllers.ViewModels;
+using dotnetLab.WebApi.Infrastructure.ResponseWrapper;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
+
+namespace dotnetLab.WebApi.Controllers;
+
+/// <summary>
+/// 貨運相關 API
+/// </summary>
+[ApiController]
+[Route("api/v{version:apiVersion}/shipments")]
+public class ShipmentsController : ControllerBase
+{
+    private readonly IMessageBus _messageBus;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    public ShipmentsController(IMessageBus messageBus)
+    {
+        this._messageBus = messageBus;
+    }
+
+    /// <summary>
+    /// 取得貨運
+    /// </summary>
+    /// <param name="shipmentId"></param>
+    /// <returns></returns>
+    [HttpGet("{shipmentId}")]
+    [ProducesResponseType<ApiResponse<ShipmentViewModel>>(200)]
+    public async Task<IActionResult> Get(Guid shipmentId)
+    {
+        var dto = await this._messageBus.InvokeAsync<ShipmentDto?>(new GetShipmentQuery { ShipmentId = shipmentId });
+        if (dto == null)
+        {
+            return this.NotFound();
+        }
+
+        var vm = new ShipmentViewModel
+        {
+            Id = dto.Id,
+            TrackingNumber = dto.TrackingNumber,
+            Status = dto.Status
+        };
+        return this.Ok(vm);
+    }
+}

--- a/src/dotnetLab.WebApi/Controllers/ViewModels/OrderViewModel.cs
+++ b/src/dotnetLab.WebApi/Controllers/ViewModels/OrderViewModel.cs
@@ -1,0 +1,27 @@
+namespace dotnetLab.WebApi.Controllers.ViewModels;
+
+/// <summary>
+/// 訂單資料
+/// </summary>
+public class OrderViewModel
+{
+    /// <summary>
+    /// 訂單識別碼
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 客戶名稱
+    /// </summary>
+    public string CustomerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 訂單日期
+    /// </summary>
+    public DateTime OrderDate { get; set; }
+
+    /// <summary>
+    /// 總金額
+    /// </summary>
+    public decimal TotalAmount { get; set; }
+}

--- a/src/dotnetLab.WebApi/Controllers/ViewModels/ShipmentViewModel.cs
+++ b/src/dotnetLab.WebApi/Controllers/ViewModels/ShipmentViewModel.cs
@@ -1,0 +1,22 @@
+namespace dotnetLab.WebApi.Controllers.ViewModels;
+
+/// <summary>
+/// 貨運資料
+/// </summary>
+public class ShipmentViewModel
+{
+    /// <summary>
+    /// 貨運識別碼
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 追蹤號碼
+    /// </summary>
+    public string TrackingNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 狀態
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- implement mock repositories for orders and shipments
- create order and shipment use cases
- wire DI for new repositories
- expose basic order and shipment controllers

## Testing
- `dotnet format src/dotnet-lab.sln`
- `dotnet build src/dotnet-lab.sln -c Release --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6845073a2204832298d9221cb828ca85